### PR TITLE
Avoid notifying when the hash is the question ID

### DIFF
--- a/CheckForExistingCorA.user.js
+++ b/CheckForExistingCorA.user.js
@@ -44,7 +44,8 @@
                 } else {
                     showMessage(document.getElementById('comment-'+ ids[0]), 'comment');
                 }
-            } else {
+            // Make sure the hash is not the ID of the question.
+            } else if (window.location.pathname.indexOf('/questions/' + cleanHash) !== 0) {
                 if (!isNaN(Number.parseInt(cleanHash, 10))) {
                     showMessage(document.getElementById('answer-' + cleanHash), 'answer');
                 }


### PR DESCRIPTION
When the hash is the question ID (which is not even deleted in most cases), the script thinks that it's a deleted answer and shows the corresponding notification. This happens, for example, when reloading a question after it was edited.